### PR TITLE
Fix out of scope arguments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Stage 1: Base
 FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 as base
 
-ARG WEBUI_VERSION=v1.6.0
-ARG DREAMBOOTH_COMMIT=cf086c536b141fc522ff11f6cffc8b7b12da04b9
-ARG KOHYA_VERSION=v21.8.10
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Africa/Johannesburg \
@@ -71,6 +67,10 @@ RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https:/
 
 # Stage 2: Install applications
 FROM base as setup
+
+ARG WEBUI_VERSION=v1.6.0
+ARG DREAMBOOTH_COMMIT=cf086c536b141fc522ff11f6cffc8b7b12da04b9
+ARG KOHYA_VERSION=v21.8.10
 
 RUN mkdir -p /sd-models
 


### PR DESCRIPTION
The `Dockerfile` gave me the following error when building:
```
error: pathspec 'tags/' did not match any file(s) known to git
```
when doing the RUN on `git checkout tags/${WEBUI_VERSION}`.

The ARGs are scoped to the previous FROM.   See:
- https://docs.docker.com/engine/reference/builder/#scope
- https://benkyriakou.com/posts/docker-args-empty

NOTE: It should be possible to just add:
```
ARG WEBUI_VERSION
ARG DREAMBOOTH_COMMIT
ARG KOHYA_VERSION
```
after the second FROM (stage 2) while leaving the existing arguments set in the previous FROM (stage 1), but haven't tried it.