### PR TITLE
Allow user to specify command line args for a1111 webui

### DIFF
--- a/a1111/webui-user.sh
+++ b/a1111/webui-user.sh
@@ -10,7 +10,7 @@ install_dir="/workspace"
 #clone_dir="stable-diffusion-webui"
 
 # Commandline arguments for webui.py, for example: export COMMANDLINE_ARGS="--medvram --opt-split-attention"
-export COMMANDLINE_ARGS="--port 3001 --skip-install --listen --api --xformers --enable-insecure-extension-access --no-half-vae"
+test -z "$COMMANDLINE_ARGS" || export COMMANDLINE_ARGS="--port 3001 --skip-install --listen --api --xformers --enable-insecure-extension-access --no-half-vae"
 
 # python3 executable
 #python_cmd="python3"


### PR DESCRIPTION
This should allow the user to customize flags by setting the `COMMANDLINE_ARGS` env variable in the docker run. If nothing is passed in, then the defaults are used.