### PR TITLE
Add InvokeAI Web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,16 @@ RUN git clone https://github.com/ltdrdata/ComfyUI-Manager.git custom_nodes/Comfy
     pip3 cache purge && \
     deactivate
 
+# Install InvokeAI
+ARG INVOKEAI_VERSION
+WORKDIR /InvokeAI
+RUN python3 -m venv --system-site-packages venv && \
+    source venv/bin/activate && \
+    pip3 install --no-cache-dir torch==${TORCH_VERSION} torchvision torchaudio --index-url ${INDEX_URL} && \
+    pip3 install --no-cache-dir xformers==${XFORMERS_VERSION} --index-url ${INDEX_URL} && \
+    pip3 install InvokeAI[xformers]==${INVOKEAI_VERSION} --use-pep517 && \
+    deactivate
+
 # Install Tensorboard
 RUN pip3 uninstall -y tensorboard tb-nightly && \
     pip3 install tensorboard==2.14.1 tensorflow==2.14.0
@@ -196,6 +206,9 @@ ADD https://raw.githubusercontent.com/Douleb/SDXL-750-Styles-GPT4-/main/styles.c
 
 # Copy ComfyUI Extra Model Paths (to share models with A1111)
 COPY comfyui/extra_model_paths.yaml /ComfyUI/
+
+# Copy InvokeAI config file
+COPY invokeai/invokeai.yaml /InvokeAI/
 
 # Remove existing SSH host keys
 RUN rm -f /etc/ssh/ssh_host_*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Docker image for A1111 Stable Diffusion Web UI, Kohya_ss and ComfyUI
+# Docker image for A1111 Stable Diffusion Web UI, Kohya_ss, ComfyUI and InvokeAI
 
 [![GitHub Repo](https://img.shields.io/badge/github-repo-green?logo=github)](https://github.com/ashleykleynhans/stable-diffusion-docker)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/ashleykza/stable-diffusion-webui?logo=docker&label=dockerhub&color=blue)](https://hub.docker.com/repository/docker/ashleykza/stable-diffusion-webui)
@@ -41,6 +41,7 @@ Now with SDXL support.
 * [Kohya_ss](https://github.com/bmaltais/kohya_ss) v24.1.2
 * [ComfyUI](https://github.com/comfyanonymous/ComfyUI)
 * [ComfyUI Manager](https://github.com/ltdrdata/ComfyUI-Manager)
+* [InvokeAI](https://github.com/invoke-ai/InvokeAI) v4.2.0
 * [sd_xl_base_1.0.safetensors](
   https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors)
 * [sd_xl_refiner_1.0.safetensors](
@@ -134,6 +135,7 @@ You can obviously substitute the image name and tag with your own.
 | 3000         | 3001          | A1111 Stable Diffusion Web UI |
 | 3010         | 3011          | Kohya_ss                      |
 | 3020         | 3021          | ComfyUI                       |
+| 9090         | 9090          | InvokeAI                      |
 | 6006         | 6066          | Tensorboard                   |
 | 8000         | 8000          | Application Manager           |
 | 8888         | 8888          | Jupyter Lab                   |
@@ -159,6 +161,7 @@ killing the services to view the logs
 | Stable Diffusion Web UI | /workspace/logs/webui.log    |
 | Kohya SS                | /workspace/logs/kohya_ss.log |
 | ComfyUI                 | /workspace/logs/comfyui.log  |
+| InvokeAI                | /workspace/logs/invokeai.log |
 
 ## Community and Contributing
 

--- a/app-manager/config.json
+++ b/app-manager/config.json
@@ -2,6 +2,7 @@
   "applications": [
     "A1111",
     "Kohya_ss",
-    "ComfyUI"
+    "ComfyUI",
+    "InvokeAI"
   ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -48,6 +48,7 @@ target "default" {
         DREAMBOOTH_COMMIT = "45a12fe5950bf93205b6ef2b7511eb94052a241f"
         CIVITAI_BROWSER_PLUS_VERSION = "v3.5.4"
         KOHYA_VERSION = "v24.1.2"
+        INVOKEAI_VERSION = "4.2.0"
         APP_MANAGER_VERSION = "1.0.2"
         CIVITAI_DOWNLOADER_VERSION = "2.1.0"
         VENV_PATH = "/workspace/venvs/${APP}"

--- a/invokeai/invokeai.yaml
+++ b/invokeai/invokeai.yaml
@@ -1,0 +1,7 @@
+# Internal metadata - do not edit:
+schema_version: 4.0.1
+
+# Put user settings here - see https://invoke-ai.github.io/InvokeAI/features/CONFIGURATION/:
+host: 127.0.0.1
+port: 9091
+hashing_algorithm: sha256 # to match a1111

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -231,4 +231,54 @@ http {
             rewrite ^(.*)$ /502.html break;
         }
     }
+
+    # InvokeAI
+    server {
+        listen 9090;
+
+        location /ws {
+            proxy_http_version 1.1;
+            proxy_set_header Accept-Encoding gzip;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            add_header Cache-Control no-cache;
+            proxy_set_header Host $host;
+
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Real-IP		$remote_addr;
+            proxy_pass http://localhost:9091;
+        }
+
+        location / {
+            add_header Cache-Control no-cache;
+            proxy_pass http://localhost:9091;
+            proxy_http_version 1.1;
+            proxy_set_header Accept-Encoding gzip;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Host $host;
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_intercept_errors on;
+            error_page 502 =200 @502;
+        }
+
+        location /README.md {
+            root /usr/share/nginx/html;
+        }
+
+        location @502 {
+            # kill cache
+            add_header Last-Modified $date_gmt;
+            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+            if_modified_since off;
+            expires off;
+            etag off;
+
+            root /usr/share/nginx/html;
+            rewrite ^(.*)$ /502.html break;
+        }
+    }
 }

--- a/scripts/pre_start.sh
+++ b/scripts/pre_start.sh
@@ -35,6 +35,11 @@ sync_apps() {
     rsync --remove-source-files -rlptDu /ComfyUI/ /workspace/ComfyUI/
     rm -rf /ComfyUI
 
+    # Sync InvokeAI to workspace to support Network volumes
+    echo "Syncing InvokeAI to workspace, please wait..."
+    rsync --remove-source-files -rlptDu /InvokeAI/ /workspace/InvokeAI/
+    rm -rf /InvokeAI
+
     # Sync Application Manager to workspace to support Network volumes
     echo "Syncing Application Manager to workspace, please wait..."
     rsync --remove-source-files -rlptDu /app-manager/ /workspace/app-manager/
@@ -53,6 +58,9 @@ fix_venvs() {
 
     echo "Fixing ComfyUI venv..."
     /fix_venv.sh /ComfyUI/venv /workspace/ComfyUI/venv
+
+    echo "Fixing InvokeAI venv..."
+    /fix_venv.sh /InvokeAI/venv /workspace/InvokeAI/venv
 }
 
 link_models() {
@@ -117,6 +125,7 @@ else
     /start_a1111.sh
     /start_kohya.sh
     /start_comfyui.sh
+    /start_invokeai.sh
 fi
 
 if [ ${ENABLE_TENSORBOARD} ];

--- a/scripts/start_invokeai.sh
+++ b/scripts/start_invokeai.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+export PYTHONUNBUFFERED=1
+echo "Starting InvokeAI"
+cd /workspace/InvokeAI
+source venv/bin/activate
+nohup invokeai-web > /workspace/logs/invokeai.log 2>&1 &
+echo "InvokeAI started"
+echo "Log file: /workspace/logs/invokeai.log"
+deactivate


### PR DESCRIPTION
resolves #57 

The only (minor) caveat is that Invoke uses a semi-custom model structure therefore using the models already provided in the docker image requires a quick import from folder in the model tab.
This could probably be fixed by embedding all the extra model information generated by InvokeAI directly in the image but it might make version bumps more hazardous.