### PR TITLE
Typo in A1111 installation

### DIFF
--- a/build/install_a1111.sh
+++ b/build/install_a1111.sh
@@ -78,7 +78,7 @@ pip3 uninstall -y nvidia-cudnn-cu11
 pip3 install protobuf==3.20.2
 pip3 install polygraphy --extra-index-url https://pypi.ngc.nvidia.com
 pip3 install onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com
-pip3 install install optimum
+pip3 install optimum
 pip3 cache purge
 deactivate
 


### PR DESCRIPTION
I've mentioned in https://github.com/ashleykleynhans/stable-diffusion-docker/issues/68#issue-2432226801 that you have a typo. Looks like an easy fix, so commiting a PR right away

Subject matter:
https://github.com/ashleykleynhans/stable-diffusion-docker/blob/bfec273c43d277fcd987ce3c779a895c7568bd51/build/install_a1111.sh#L81

should be just

` pip3 install optimum`